### PR TITLE
use Ethernet_wire.sizeof_ethernet instead of a magic '14'

### DIFF
--- a/client_net.ml
+++ b/client_net.ml
@@ -80,7 +80,7 @@ let add_vif { Dao.ClientVif.domid; device_id } ~client_ip ~router ~cleanup_tasks
   Router.add_client router iface >>= fun () ->
   Cleanup.on_cleanup cleanup_tasks (fun () -> Router.remove_client router iface);
   let fixed_arp = Client_eth.ARP.create ~net:client_eth iface in
-  Netback.listen backend ~header_size:14 (fun frame ->
+  Netback.listen backend ~header_size:Ethernet_wire.sizeof_ethernet (fun frame ->
     match Ethernet_packet.Unmarshal.of_cstruct frame with
     | exception ex ->
       Log.err (fun f -> f "Error unmarshalling ethernet frame from client: %s@.%a" (Printexc.to_string ex)

--- a/uplink.ml
+++ b/uplink.ml
@@ -32,7 +32,7 @@ module Make(Clock : Mirage_clock_lwt.MCLOCK) = struct
   end
 
   let listen t router =
-    Netif.listen t.net ~header_size:14 (fun frame ->
+    Netif.listen t.net ~header_size:Ethernet_wire.sizeof_ethernet (fun frame ->
         (* Handle one Ethernet frame from NetVM *)
         Eth.input t.eth
           ~arpv4:(Arp.input t.arp)


### PR DESCRIPTION
//cc @talex5 and @yomimono -- better not to hardcode 14 anywhere (see also https://github.com/mirage/mirage-nat/pull/25)